### PR TITLE
Delete -verbose, -dontobfuscate

### DIFF
--- a/wisefy/consumer-proguard-rules.pro
+++ b/wisefy/consumer-proguard-rules.pro
@@ -1,6 +1,2 @@
--verbose
-
--dontobfuscate
-
 -keep class com.isupatches.wisefy.** { *; }
 -keep public interface com.isupatches.wisefy.** { *; }


### PR DESCRIPTION
consumer-proguard-rules.pro affects entire app and prevent obfuscation via proguard.
To prevent obfuscation of wisefy packages, remained lines are sufficient already